### PR TITLE
Allow remote deployments in sandboxed environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin/
 pkg/
 src/
+telescope

--- a/goat/apiAuthenticator_test.go
+++ b/goat/apiAuthenticator_test.go
@@ -64,7 +64,7 @@ func TestBasicAPIAuthenticator(t *testing.T) {
 	// Generate mock HTTP request
 	r := http.Request{}
 	headers := map[string][]string{
-		"Authorization": []string{"Basic " + base64.URLEncoding.EncodeToString([]byte(user.Username+":"+pass))},
+		"Authorization": {"Basic " + base64.URLEncoding.EncodeToString([]byte(user.Username+":"+pass))},
 	}
 	r.Header = headers
 

--- a/goat/config.go
+++ b/goat/config.go
@@ -48,15 +48,8 @@ func loadConfig() conf {
 		config = ".config.travis.json"
 	}
 
-	// Load current user from OS, to get home directory
-	user, err := user.Current()
-	if err != nil {
-		log.Println(err.Error())
-		path = "./"
-	} else {
-		// Store config in standard location
-		path = user.HomeDir + "/.config/goat/"
-	}
+	// Store config in standard location
+	path = user.HomeDir + "/.config/goat/"
 
 	log.Println("Loading configuration: " + path + config)
 

--- a/goat/config.go
+++ b/goat/config.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/user"
 )
 
 // dbConf represents database configuration
@@ -49,12 +48,12 @@ func loadConfig() conf {
 	}
 
 	// Store config in standard location
-	path = user.HomeDir + "/.config/goat/"
+	path = "./"
 
 	log.Println("Loading configuration: " + path + config)
 
 	// Check file existence
-	_, err = os.Stat(path + config)
+	_, err := os.Stat(path + config)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Println("Could not find configuration, attempting to create it...")

--- a/goat/database_mysql.go
+++ b/goat/database_mysql.go
@@ -13,13 +13,21 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+var MysqlDSN *string
+
 // init performs startup routines for database_mysql
 func init() {
 	// dbConnectFunc connects to MySQL database
 	dbConnectFunc = func() (dbModel, error) {
+		var conn string
 		// Generate connection string using configuration
-		conn := fmt.Sprintf("%s:%s@/%s", static.Config.DB.Username, static.Config.DB.Password, static.Config.DB.Database)
+		if MysqlDSN == nil || *MysqlDSN == "" {
+			conn = fmt.Sprintf("%s:%s@/%s", static.Config.DB.Username, static.Config.DB.Password, static.Config.DB.Database)
+		} else {
+			conn = *MysqlDSN
+		}
 
+		log.Printf("dialing %s", conn)
 		// Return connection and associated errors
 		db, err := sqlx.Connect("mysql", conn)
 		return &dbw{db}, err

--- a/goat/httpConnHandler.go
+++ b/goat/httpConnHandler.go
@@ -36,9 +36,8 @@ func handleHTTP(l net.Listener, sendChan chan bool, recvChan chan bool) {
 	if err := http.Serve(l, nil); err != nil {
 		// Ignore connection closing error, caused by stopping listener
 		if !strings.Contains(err.Error(), "use of closed network connection") {
-			log.Println(err.Error())
 			log.Println("Could not serve HTTP(S), exiting now")
-			os.Exit(1)
+			panic(err)
 		}
 	}
 }

--- a/goat/listener.go
+++ b/goat/listener.go
@@ -13,9 +13,8 @@ func listenHTTP(sendChan chan bool, recvChan chan bool) {
 	// Listen on specified TCP port
 	l, err := net.Listen("tcp", ":"+strconv.Itoa(static.Config.Port))
 	if err != nil {
-		log.Println(err.Error())
 		log.Println("Cannot start HTTP server, exiting now.")
-		os.Exit(1)
+		panic(err)
 	}
 
 	// Send listener to handler
@@ -27,9 +26,8 @@ func listenHTTPS(sendChan chan bool, recvChan chan bool) {
 	// Load certificate and key
 	cert, err := tls.LoadX509KeyPair(static.Config.SSL.Certificate, static.Config.SSL.Key)
 	if err != nil {
-		log.Println(err.Error())
 		log.Println("Cannot load HTTPS X509 key pair, exiting now.")
-		os.Exit(1)
+		panic(err)
 	}
 
 	// SSL configuration
@@ -40,9 +38,8 @@ func listenHTTPS(sendChan chan bool, recvChan chan bool) {
 	// Listen on specified SSL port
 	l, err := tls.Listen("tcp", ":"+strconv.Itoa(static.Config.SSL.Port), &sslConfig)
 	if err != nil {
-		log.Println(err.Error())
 		log.Println("Cannot start HTTPS server, exiting now.")
-		os.Exit(1)
+		panic(err)
 	}
 
 	// Send listener to handler

--- a/goat/listener.go
+++ b/goat/listener.go
@@ -11,7 +11,7 @@ import (
 // Listen and handle HTTP (TCP) connections
 func listenHTTP(sendChan chan bool, recvChan chan bool) {
 	// Listen on specified TCP port
-	l, err := net.Listen("tcp", ":" + strconv.Itoa(static.Config.Port))
+	l, err := net.Listen("tcp", ":"+strconv.Itoa(static.Config.Port))
 	if err != nil {
 		log.Println(err.Error())
 		log.Println("Cannot start HTTP server, exiting now.")
@@ -38,7 +38,7 @@ func listenHTTPS(sendChan chan bool, recvChan chan bool) {
 	}
 
 	// Listen on specified SSL port
-	l, err := tls.Listen("tcp", ":" + strconv.Itoa(static.Config.SSL.Port), &sslConfig)
+	l, err := tls.Listen("tcp", ":"+strconv.Itoa(static.Config.SSL.Port), &sslConfig)
 	if err != nil {
 		log.Println(err.Error())
 		log.Println("Cannot start HTTPS server, exiting now.")
@@ -52,7 +52,7 @@ func listenHTTPS(sendChan chan bool, recvChan chan bool) {
 // Listen on specified UDP port, accept and handle connections
 func listenUDP(sendChan chan bool, recvChan chan bool) {
 	// Listen on specified UDP port
-	addr, err := net.ResolveUDPAddr("udp", ":" + strconv.Itoa(static.Config.Port))
+	addr, err := net.ResolveUDPAddr("udp", ":"+strconv.Itoa(static.Config.Port))
 	l, err := net.ListenUDP("udp", addr)
 	if err != nil {
 		log.Println(err.Error())

--- a/goat/manager.go
+++ b/goat/manager.go
@@ -96,7 +96,7 @@ func Manager(killChan chan bool, exitChan chan int) {
 
 			// If program hangs for more than 10 seconds, trigger a force halt
 			go func() {
-				time.Sleep(10 * time.Second)
+				<-time.After(10 * time.Second)
 				log.Println("Timeout reached, triggering force halt")
 				if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
 					log.Println(err.Error())

--- a/goat/manager.go
+++ b/goat/manager.go
@@ -34,14 +34,14 @@ func Manager(killChan chan bool, exitChan chan int) {
 	config := loadConfig()
 	if config == (conf{}) {
 		log.Println("Cannot load configuration, exiting now.")
-		os.Exit(1)
+		panic(err)
 	}
 	static.Config = config
 
 	// Check for sane announce interval (10 minutes or more)
 	if static.Config.Interval <= 600 {
 		log.Println("Announce interval must be at least 600 seconds.")
-		os.Exit(1)
+		panic(err)
 	}
 
 	// Attempt database connection
@@ -64,7 +64,7 @@ func Manager(killChan chan bool, exitChan chan int) {
 	if static.Config.Redis {
 		if !redisPing() {
 			log.Println("Cannot connect to Redis, exiting now.")
-			os.Exit(1)
+			panic(err)
 		}
 		log.Println("Redis : OK")
 	}

--- a/goat/manager.go
+++ b/goat/manager.go
@@ -1,6 +1,7 @@
 package goat
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -45,10 +46,19 @@ func Manager(killChan chan bool, exitChan chan int) {
 
 	// Attempt database connection
 	if !dbPing() {
-		log.Println("Cannot connect to database", dbName(), ", exiting now.")
-		os.Exit(1)
+		panic(fmt.Errorf("Cannot connect to database", dbName(), ", exiting now."))
 	}
 	log.Println("Database", dbName(), ": OK")
+
+	db, err := dbConnectFunc()
+	if err != nil {
+	}
+	for _, schema := range mysql_schemas {
+		_ = (db).(*dbw).Execf(schema)
+		if err != nil {
+			panic(err)
+		}
+	}
 
 	// If configured, attempt redis connection
 	if static.Config.Redis {

--- a/goat/manager.go
+++ b/goat/manager.go
@@ -46,7 +46,7 @@ func Manager(killChan chan bool, exitChan chan int) {
 
 	// Attempt database connection
 	if !dbPing() {
-		panic(fmt.Errorf("Cannot connect to database", dbName(), ", exiting now."))
+		panic(fmt.Errorf("Cannot connect to database %s; exiting now", dbName()))
 	}
 	log.Println("Database", dbName(), ": OK")
 

--- a/goat/mysql_schemas.go
+++ b/goat/mysql_schemas.go
@@ -1,0 +1,79 @@
+package goat
+
+var mysql_schemas = []string{`
+CREATE TABLE IF NOT EXISTS announce_log (
+	id int(11) NOT NULL AUTO_INCREMENT
+	, info_hash varchar(40) NOT NULL
+	, passkey char(40) NOT NULL
+	, ` + "`key` " + `char(8) NOT NULL
+	, ip varchar(15) NOT NULL
+	, port int(11) NOT NULL
+	, udp tinyint(1) NOT NULL
+	, uploaded bigint unsigned NOT NULL
+	, downloaded bigint unsigned NOT NULL
+	, ` + "`left` " + `bigint unsigned NOT NULL
+	, event varchar(10) NOT NULL
+	, client varchar(50) NOT NULL
+	, time int(11) NOT NULL
+	, PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`,
+	`CREATE TABLE IF NOT EXISTS api_keys (
+	id int(11) NOT NULL AUTO_INCREMENT
+	, ` + "`user_id` " + `int(11) NOT NULL
+	, ` + "`key` " + `char(40) NOT NULL
+	, ` + "`salt` " + `char(20) NOT NULL
+	, PRIMARY KEY (id)
+	, UNIQUE KEY (user_id)
+	, UNIQUE KEY (` + "`key`" + `)
+	, UNIQUE KEY (salt)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`,
+	`CREATE TABLE IF NOT EXISTS files (
+	id int(11) NOT NULL AUTO_INCREMENT
+	, info_hash varchar(40) NOT NULL
+	, verified tinyint(1) NOT NULL
+	, create_time int(11) NOT NULL
+	, update_time int(11) NOT NULL
+	, PRIMARY KEY (id)
+	, UNIQUE KEY (info_hash)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`,
+	`CREATE TABLE IF NOT EXISTS files_users (
+	file_id int(11) NOT NULL
+	, ` + "`user_id` " + `int(11) NOT NULL
+	, ip varchar(15) NOT NULL
+	, active tinyint(1) NOT NULL
+	, completed tinyint(1) NOT NULL
+	, announced int(11) NOT NULL
+	, uploaded bigint unsigned NOT NULL
+	, downloaded bigint unsigned NOT NULL
+	, ` + "`left` " + `bigint unsigned NOT NULL
+	, time int(11) NOT NULL
+	, UNIQUE KEY (file_id, user_id, ip)
+	, KEY (file_id)
+	, KEY (file_id)
+	, KEY (ip)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`,
+	`CREATE TABLE IF NOT EXISTS scrape_log (
+	id int(11) NOT NULL AUTO_INCREMENT
+	, info_hash char(40) NOT NULL
+	, passkey char(40) NOT NULL
+	, ip varchar(15) NOT NULL
+	, time int(11) NOT NULL
+	, PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`,
+	`CREATE TABLE IF NOT EXISTS users (
+	id int(11) NOT NULL AUTO_INCREMENT
+	, username varchar(20) NOT NULL
+	, passkey char(40) NOT NULL
+	, torrent_limit int(11) NOT NULL
+	, PRIMARY KEY (id)
+	, UNIQUE KEY (username)
+	, UNIQUE KEY (passkey)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`,
+	`CREATE TABLE IF NOT EXISTS whitelist (
+	id int(11) NOT NULL AUTO_INCREMENT
+	, client varchar(50) NOT NULL
+	, approved tinyint(1) NOT NULL
+	, PRIMARY KEY (id)
+	, UNIQUE KEY (client)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
+`}

--- a/goat/redis.go
+++ b/goat/redis.go
@@ -7,9 +7,20 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
+var RedisPass *string
+
 // redisConnect initiates a connection to Redis server
-func redisConnect() (redis.Conn, error) {
-	return redis.Dial("tcp", ":6379")
+func redisConnect() (c redis.Conn, err error) {
+	c, err = redis.Dial("tcp", "crestfish.redistogo.com:11107")
+	if err != nil {
+		return
+	}
+
+	// Authenticate with Redis database if necessary
+	if RedisPass != nil && *RedisPass != "" {
+		_, err = c.Do("AUTH", RedisPass)
+	}
+	return
 }
 
 // redisPing verifies that Redis server is available

--- a/main.go
+++ b/main.go
@@ -11,10 +11,17 @@ import (
 	"github.com/mdlayher/goat/goat"
 )
 
+var test = flag.Bool("test", false, "Make goat start, and exit shortly after. Used for testing.")
+var redisPass = flag.String("redispass", "", "password for the Redis database, if any")
+var mysqlDSN = flag.String("mysqldsn", "", "msql data source name")
+
 func main() {
 	// Set up command line options
-	test := flag.Bool("test", false, "Make goat start, and exit shortly after. Used for testing.")
 	flag.Parse()
+
+	// Set password for Redis database and DSN for MySQL database
+	goat.RedisPass = redisPass
+	goat.MysqlDSN = mysqlDSN
 
 	// If test mode, trigger quit shortly after startup
 	// Used for CI tests, so that we ensure goat starts up and is able to stop gracefully

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mdlayher/goat/goat"
+	"github.com/ChimeraCoder/telescope/goat"
 )
 
 var test = flag.Bool("test", false, "Make goat start, and exit shortly after. Used for testing.")


### PR DESCRIPTION
First - thanks for writing this... my friends want to distribute some large video files that they've filmed, and this gives us a good excuse to set up a dedicated tracker.

I've made a number of fixes here, mostly related to the process of running this within sandboxed environments (eg. Heroku, Google App Engine).
- The MySQL connection assumes that the database is running on the local machine. I've added a command-line flag to specify an arbitrary MySQL DSN
- The Redis database also assumes that it is running on the local machine - I've updated it to allow for a remote database 
- Both databases assume that no credentials are required  - I have added a flag to specify a password for the Redis database (if needed). The MySQL credentials can be stored within the DSN, so no separate flag is needed.
- `time.Sleep` has been replaced with `time.After`, which is more reliable
- I've replaced all calls within the internal `goat` package (but not package `main`) to `os.Exit` with `panic`.  Technically, non-main packages should not call either one, but `panic` is more idiomatic than `os.Exit`, as it is possible to `recover` from a panic, but `os.Exit` forces the main program to terminate, whether it wants to or not. `panic` also already returns a status code of `1` to the caller if it forces the program to terminate. Eventually, you may want to replace the `panic` calls with returned errors, but this is fine for now.
- I've modified the configuration to default to the present working directory. Offering `~/.config/goat` is fine as an option, but Go packages generally shouldn't assume they have write access outside their own directories, and this causes problems on sandboxed environments like Heroku.
- The MySQL connection will fail the first time the program is run, because the tables don't yet exist (and the program doesn't try to create them). The way I've fixed it here assumes that there is a MySQL - if you want to allow for QL databases as well, you may want to modify this patch (dc28802).
